### PR TITLE
Problema al editar intervención jefatura

### DIFF
--- a/admin/jefatura/index.php
+++ b/admin/jefatura/index.php
@@ -95,7 +95,7 @@ if (isset($_POST['submit1'])) {
 }
 
 if (isset($_POST['submit2'])) {
-	$dia = explode("-",$fecha);
+	$dia = explode("-",$fecha_reg);
 	$fecha2 = "$dia[2]-$dia[1]-$dia[0]";
 	$actualizar ="UPDATE  tutoria SET observaciones = '$observaciones', causa = '$causa', accion = '$accion', fecha = '$fecha2', prohibido = '$prohibido' WHERE  id = '$id2'";
 	mysqli_query($db_con, $actualizar);


### PR DESCRIPTION
Al editar una fechoría se guarda con fecha 00-00-0000 porque se utilizaba la variable fecha en lugar de fecha_reg que es la que se recupera del formulario.