### PR TITLE
Problema con matrícula trasladada

### DIFF
--- a/xml/jefe/alma.php
+++ b/xml/jefe/alma.php
@@ -171,8 +171,8 @@ include("../../menu.php");
 							$lineasalto.=$dato;
 							$lineasalto.=");";
 							$consulta=explode(',',$lineasalto);
-							//Comprobamos que la matrícula no haya sido anulada para añadirla
-							if (!preg_match('*Anulada*', $consulta[2])){
+							//Comprobamos que la matrícula no haya sido anulada o trasladada para añadirla
+							if (!preg_match('*Anulada*', $consulta[2]) and !preg_match('*Trasladada*',$consutal[2]){
 								mysqli_query($db_con, $lineasalto);
 							}		
 						}


### PR DESCRIPTION
Esto no es habitual, pero en nuestro centro una alumna solicitó el traslado de matrícula y luego ha vuelto, con lo que al realizar la exportación de Séneca aparece primero el traslado y luego la matrícula en el fichero, por lo que  no se carga la alumna.