### PR TITLE
Integración de include para uso propio de maralboran.eu

### DIFF
--- a/reservas/reservar/index_aulas.php
+++ b/reservas/reservar/index_aulas.php
@@ -202,7 +202,10 @@ if ($servicio) {
 </small>
 </h2>
 </div>
-
+<?php
+// CONSULTA DE NORMAS DE USO DE LAS DISTINTAS DEPENDENCIAS
+if (file_exists('normas_dependencias.php') && $_SERVER['SERVER_NAME']=="maralboran.eu") {
+	include('normas_dependencias.php'); }?>
 <?php if (isset($mens)): ?> <?php if ($mens == 'actualizar'): ?>
 <div class="alert alert-success">La reserva se ha actualizado
 correctamente.</div>


### PR DESCRIPTION
El objetivo es llamar al archivo normas_dependencias.php donde tener las llamadas a los distintos archivos de normas de las distintas dependencias (salon de actos, aulas tic, aulas con PDI, SDI, etc..) La llamada se hace como un link que aparece encima de cada calendario (se puede poner en otro sitio) desde el cual accedemos a las normas.
Adjunto un ejemplo de lo que contiene el archivo normas_dependencias.php.

[normas_dependencias.zip](https://github.com/IESMonterroso/intranet/files/2750825/normas_dependencias.zip)

Si os gusta la idea lo podeis modificar para usarlo todos. Cada centro modificaría su propio archivo de 
normas. De momento lo incorporo para uso propio.