### PR TITLE
Update consulta_mesas.php (añado campo 'estructura' a la bd 'puestos_alumnos')

### DIFF
--- a/admin/tutoria/consulta_mesas.php
+++ b/admin/tutoria/consulta_mesas.php
@@ -29,6 +29,11 @@ mysqli_query($db_con, "CREATE TABLE IF NOT EXISTS `puestos_alumnos` (
   `estructura` varchar(10) COLLATE utf8_general_ci NOT NULL,
   PRIMARY KEY (`unidad`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci");
+//Si no existe la columna 'estructura' la creo
+$col = mysqli_query($db_con, "SELECT `estructura` FROM `puestos_alumnos`");
+if (!$col){
+	mysqli_query($db_con, "ALTER TABLE `puestos_alumnos` ADD `estructura` varchar(10) COLLATE utf8_general_ci NOT NULL");
+}
 // ESTRUCTURA DE LA CLASE, SE AJUSTA AL NUMERO DE ALUMNOS
 $result = mysqli_query($db_con, "SELECT apellidos, nombre, claveal FROM alma WHERE unidad='".$_SESSION['mod_tutoria']['unidad']."' ORDER BY apellidos ASC, nombre ASC");
 $n_alumnos = mysqli_num_rows($result);


### PR DESCRIPTION
Aviso: 
Con php 5.6 todo funciona ok. 
Con php 7.1 la variable $_SESSION['mesas']['estructura'] no conserva su valor tras darle al boton guardar (y por tanto no guarda la estructura) .
Con php 7.2 pantalla en blanco.

consulta_mesas_tic tiene una estructura muy similar y si me la guarda bien. Por más que lo reviso no lo detecto.

SOLUCIONADO