### PR TITLE
Amplia los permisos de las fileactions a los subdirectorios creados p…

### DIFF
--- a/documentos/config.php
+++ b/documentos/config.php
@@ -106,7 +106,7 @@ function ft_settings_external_load() {
     $ft["settings"]["ADVANCEDACTIONS"]   = FALSE; // Set to TRUE to enable advanced actions like chmod and symlinks.
   }
   // Permisos de todos los profesores para la carpeta de su departamento
-  elseif (! acl_permiso($_SESSION['cargo'], array('1')) && ($depto_profesor == $dir || $depto_profesor_sin_tildes == $dir)) {
+  elseif (! acl_permiso($_SESSION['cargo'], array('1')) && (strpos("-".$dir, $depto_profesor) == 1 || strpos("-".$dir, $depto_profesor_sin_tildes) == 1)) {
     $ft["settings"]["UPLOAD"]            = TRUE; // Set to FALSE if you want to disable file uploads.
     $ft["settings"]["CREATE"]            = TRUE; // Set to FALSE if you want to disable file/folder/url creation.
     $ft["settings"]["FILEACTIONS"]       = TRUE; // Set to FALSE if you want to disable file actions (rename, move, delete, edit, duplicate).


### PR DESCRIPTION
…or el profesor en la carpeta de su departamento

No sé si es por alguna política que tengáis establecida, pero no era posible crear directorios ni subir archivos a los directorios creados por un profesor en la carpeta publica de su departamento. Como administrador no había ningún problema.

No obstante, hay un problema grave que no he solventado (apenas he revisado el código) y que es el siguiente:
Si no eres administrador e intentas borrar un archivo o una carpeta de tu departamento no lo consigues y además se muestra la lista de archivos vacía, requiriendo refrescar la pantalla para volver a verlos. La opción de mover no la he probado.