### PR TITLE
Ligera corrección en documentos

### DIFF
--- a/documentos/config.php
+++ b/documentos/config.php
@@ -114,7 +114,7 @@ function ft_settings_external_load() {
     $ft["settings"]["ADVANCEDACTIONS"]   = FALSE; // Set to TRUE to enable advanced actions like chmod and symlinks.
   }
   // Permisos de todos los profesores para la carpeta de su departamento
-  elseif (! acl_permiso($_SESSION['cargo'], array('1')) && (strpos("-".$dir, $depto_profesor) == true || strpos("-".$dir, $depto_profesor_sin_tildes) == true)) {
+  elseif (! acl_permiso($_SESSION['cargo'], array('1')) && (strpos($dir, $depto_profesor) === 0 || strpos($dir, $depto_profesor_sin_tildes) === 0)) {
     $ft["settings"]["UPLOAD"]            = TRUE; // Set to FALSE if you want to disable file uploads.
     $ft["settings"]["CREATE"]            = TRUE; // Set to FALSE if you want to disable file/folder/url creation.
     $ft["settings"]["FILEACTIONS"]       = TRUE; // Set to FALSE if you want to disable file actions (rename, move, delete, edit, duplicate).


### PR DESCRIPTION
Para obligar  que la coincidencia se produzca al comienzo, en la posición 0 de la cadena. (Aunque va a ser muy raro que se dé una situación en la que eso no ocurra).